### PR TITLE
Update Python version for heroku-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You need following:
 
 # Heroku 
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/deeplook/slackipy/tree/master)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/avinassh/slackipy/tree/master)
 
 # Openshift 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You need following:
 
 # Heroku 
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/avinassh/slackipy/tree/master)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/deeplook/slackipy/tree/master)
 
 # Openshift 
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.9.7


### PR DESCRIPTION
Right now it gives:

```
-----> Building on the Heroku-20 stack
-----> Determining which buildpack to use for this app
-----> Python app detected
-----> Using Python version specified in runtime.txt
 !     Requested runtime (python-3.6.1) is not available for this stack (heroku-20).
 !     Aborting.  More info: https://devcenter.heroku.com/articles/python-support
 !     Push rejected, failed to compile Python app.
 !     Push failed
```